### PR TITLE
Reduce data in background

### DIFF
--- a/src/main/java/org/cirdles/calamari/core/RawDataFileHandler.java
+++ b/src/main/java/org/cirdles/calamari/core/RawDataFileHandler.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Consumer;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
@@ -39,6 +40,8 @@ public class RawDataFileHandler {
     private static Unmarshaller jaxbUnmarshaller;
     private static String currentPrawnFileLocation = "https://raw.githubusercontent.com/bowring/XSD/master/SHRIMP/EXAMPLE_100142_G6147_10111109.43_10.33.37%20AM.xml";
     //"/Users/sbowring/Google Drive/_ETRedux_ProjectData/SHRIMP/100142_G6147_10111109.43.xml"
+
+    private static Consumer<Integer> progressSubscriber;
 
     /**
      *
@@ -61,6 +64,11 @@ public class RawDataFileHandler {
             shrimpFraction.setSpotNumber(f + 1);
             shrimpFraction.setNameOfMount(nameOfMount);
             shrimpFractions.add(shrimpFraction);
+
+            if (progressSubscriber != null) {
+                int progress = (f + 1) * 100 / prawnFile.getRuns();
+                progressSubscriber.accept(progress);
+            }
         }
 
         return shrimpFractions;
@@ -138,6 +146,10 @@ public class RawDataFileHandler {
      */
     public static void setCurrentPrawnFileLocation(String aCurrentPrawnFileLocation) {
         currentPrawnFileLocation = aCurrentPrawnFileLocation;
+    }
+
+    public static void setProgressSubscriber(Consumer<Integer> progressSubscriber) {
+        RawDataFileHandler.progressSubscriber = progressSubscriber;
     }
 
 }

--- a/src/main/java/org/cirdles/calamari/userInterface/CalamariUI.form
+++ b/src/main/java/org/cirdles/calamari/userInterface/CalamariUI.form
@@ -154,7 +154,7 @@
           </Events>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="170" y="365" width="380" height="30"/>
+              <AbsoluteConstraints x="80" y="360" width="380" height="30"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -292,6 +292,13 @@
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
               <AbsoluteConstraints x="145" y="190" width="-1" height="-1"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JProgressBar" name="reduceDataProgressBar">
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
+              <AbsoluteConstraints x="476" y="360" width="170" height="30"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/src/main/java/org/cirdles/calamari/userInterface/CalamariUI.java
+++ b/src/main/java/org/cirdles/calamari/userInterface/CalamariUI.java
@@ -22,7 +22,6 @@ import java.awt.Toolkit;
 import java.io.File;
 import java.io.IOException;
 import javax.swing.UIManager;
-import javax.xml.bind.JAXBException;
 import org.cirdles.calamari.Calamari;
 import org.cirdles.calamari.core.RawDataFileHandler;
 import org.cirdles.calamari.core.ReportsEngine;
@@ -105,6 +104,7 @@ public class CalamariUI extends javax.swing.JFrame {
         calamariInfo = new javax.swing.JLabel();
         useSBM = new javax.swing.JCheckBox();
         userLinFits = new javax.swing.JCheckBox();
+        reduceDataProgressBar = new javax.swing.JProgressBar();
         menuBar = new javax.swing.JMenuBar();
         fileMenu = new javax.swing.JMenu();
         openMenuItem = new javax.swing.JMenuItem();
@@ -138,7 +138,7 @@ public class CalamariUI extends javax.swing.JFrame {
                 reduceDataButtonActionPerformed(evt);
             }
         });
-        basePane.add(reduceDataButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(170, 365, 380, 30));
+        basePane.add(reduceDataButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(80, 360, 380, 30));
 
         selectReportsLocationButton.setFont(new java.awt.Font("Arial", 0, 16)); // NOI18N
         selectReportsLocationButton.setText("Select location for CalamariReports Folder");
@@ -193,6 +193,7 @@ public class CalamariUI extends javax.swing.JFrame {
         userLinFits.setText("user LinFits");
         userLinFits.setOpaque(true);
         basePane.add(userLinFits, new org.netbeans.lib.awtextra.AbsoluteConstraints(145, 190, -1, -1));
+        basePane.add(reduceDataProgressBar, new org.netbeans.lib.awtextra.AbsoluteConstraints(476, 360, 170, 30));
 
         fileMenu.setMnemonic('f');
         fileMenu.setText("File");
@@ -259,11 +260,10 @@ public class CalamariUI extends javax.swing.JFrame {
     }//GEN-LAST:event_exitMenuItemActionPerformed
 
     private void reduceDataButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_reduceDataButtonActionPerformed
-        try {
-            RawDataFileHandler.writeReportsFromPrawnFile(RawDataFileHandler.getCurrentPrawnFileLocation(), useSBM.isSelected(), userLinFits.isSelected());
-        } catch (IOException | JAXBException exception) {
-            System.out.println("Exception extracting data: " + exception.getStackTrace()[0].toString());
-        }
+        new ReduceDataWorker(
+                useSBM.isSelected(),
+                userLinFits.isSelected(),
+                reduceDataProgressBar).execute();
     }//GEN-LAST:event_reduceDataButtonActionPerformed
 
     private void selectReportsLocationButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_selectReportsLocationButtonActionPerformed
@@ -311,6 +311,7 @@ public class CalamariUI extends javax.swing.JFrame {
     private javax.swing.JLabel outputFileLocationLabel;
     private javax.swing.JLabel outputFolderLocation;
     private javax.swing.JButton reduceDataButton;
+    private javax.swing.JProgressBar reduceDataProgressBar;
     private javax.swing.JMenuItem saveAsMenuItem;
     private javax.swing.JMenuItem saveMenuItem;
     private javax.swing.JButton selectPrawnFileLocationButton;

--- a/src/main/java/org/cirdles/calamari/userInterface/ReduceDataWorker.java
+++ b/src/main/java/org/cirdles/calamari/userInterface/ReduceDataWorker.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.calamari.userInterface;
+
+import java.io.IOException;
+import java.util.List;
+import javax.swing.JProgressBar;
+import javax.swing.SwingWorker;
+import javax.xml.bind.JAXBException;
+import org.cirdles.calamari.core.RawDataFileHandler;
+
+/**
+ * Reduces data in the background, updating the UI as it works.
+ *
+ * @author John Zeringue
+ */
+public class ReduceDataWorker extends SwingWorker<Void, Integer> {
+
+    private final boolean useSBM;
+    private final boolean userLinFits;
+    private final JProgressBar progressBar;
+
+    public ReduceDataWorker(
+            boolean useSBM,
+            boolean userLinFits,
+            JProgressBar progressBar) {
+
+        this.useSBM = useSBM;
+        this.userLinFits = userLinFits;
+        this.progressBar = progressBar;
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        RawDataFileHandler.setProgressSubscriber(progress -> publish(progress));
+
+        try {
+            RawDataFileHandler.writeReportsFromPrawnFile(
+                    RawDataFileHandler.getCurrentPrawnFileLocation(),
+                    useSBM,
+                    userLinFits);
+        } catch (IOException | JAXBException exception) {
+            System.out.println("Exception extracting data: "
+                    + exception.getStackTrace()[0].toString());
+        }
+
+        RawDataFileHandler.setProgressSubscriber(null);
+
+        return null;
+    }
+
+    @Override
+    protected void process(List<Integer> chunks) {
+        int latestValue = chunks.get(chunks.size() - 1);
+        progressBar.setValue(latestValue);
+    }
+
+    @Override
+    protected void done() {
+        progressBar.setValue(0);
+    }
+
+}


### PR DESCRIPTION
Updated the UI to perform data reduction off the UI thread. In order to
provide feedback to the user, a progress bar indicates whether or not
the process is running. This change allows UI interations while data
reduction is in progress.