### PR TITLE
Skip tests by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>dd MMMM yyyy</maven.build.timestamp.format>
+
+        <skipTests>true</skipTests>
     </properties>
     
     <!--Need SCM -->
@@ -127,8 +129,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
-                    <!-- test switch -->
-                    <skipTests>true</skipTests>
+                    <skipTests>${skipTests}</skipTests>
                     <includes>
                         <include>**/*Test.java</include>
                         <include>**/*IT.java</include>


### PR DESCRIPTION
Instead of always skipping tests, this change allows tests to be run
from the command line without modifying `pom.xml` by adding the flag
`-DskipTests=false` instead.

See
http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-test.html
for documentation.