### PR TITLE
Allow sudo in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 jdk:
 - oraclejdk8
 
-sudo: false
+sudo: true
 cache:
   directories:
   - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,6 @@
         
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>dd MMMM yyyy</maven.build.timestamp.format>
-
-        <skipTests>true</skipTests>
     </properties>
     
     <!--Need SCM -->
@@ -129,7 +127,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
-                    <skipTests>${skipTests}</skipTests>
                     <includes>
                         <include>**/*Test.java</include>
                         <include>**/*IT.java</include>


### PR DESCRIPTION
Allows the use of sudo in Travis CI in an attempt to fix the test suite.
Allowing sudo causes Travis to execute the build in a different
environment.

As part of this commit, the "skip tests by default" functionality from
pull request #21 is changed to "run tests by default". The addition of
the flag `-DskipTests` skips any tests as before.