### PR TITLE
Web main uses port 80

### DIFF
--- a/web/src/main/java/org/cirdles/calamari/web/Main.java
+++ b/web/src/main/java/org/cirdles/calamari/web/Main.java
@@ -30,7 +30,7 @@ public class Main {
 
     public static void main(String[] args) {
         URI baseUri = UriBuilder.fromUri("http://localhost/")
-                .port(9998)
+                .port(80)
                 .build();
 
         ResourceConfig config = new ResourceConfig(PrawnResource.class);


### PR DESCRIPTION
Changed the main for web to use port 80. This allows it to work under a standard firewall configuration.