### PR TITLE
Two bug fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ subprojects {
     apply plugin: "java"
 
     group = "org.cirdles"
-    version = "1.1.0"
+    version = "1.1.1"
 
     description = "Replacement for data reduction in Ludwig's Squid 2.50 for SHRIMP"
 

--- a/core/src/main/java/org/cirdles/calamari/prawn/PrawnFileRunFractionParser.java
+++ b/core/src/main/java/org/cirdles/calamari/prawn/PrawnFileRunFractionParser.java
@@ -108,7 +108,7 @@ public class PrawnFileRunFractionParser {
 
             // determine reference material status
             // hard coded for now
-            if (fractionID.startsWith("T")) {
+            if (fractionID.toUpperCase().startsWith("T")) {
                 shrimpFraction.setReferenceMaterial(true);
             }
         }

--- a/core/src/main/java/org/cirdles/calamari/prawn/PrawnFileRunFractionParser.java
+++ b/core/src/main/java/org/cirdles/calamari/prawn/PrawnFileRunFractionParser.java
@@ -484,13 +484,13 @@ public class PrawnFileRunFractionParser {
                                 double a = aPkCts[k];
                                 double b = aPkCts[numDenom];
                                 if ((a <= 0) && (b > 16)) {
-                                    zerPkCt[sNum + k - 1] = true;
+                                    zerPkCt[sNum + k] = true;
                                 }
 
                                 a = bPkCts[k];
                                 b = bPkCts[numDenom];
                                 if ((a <= 0) && (b > 16)) {
-                                    zerPkCt[sNum + k - 1] = true;
+                                    zerPkCt[sNum + k] = true;
                                 }
                             } // k iteration
 


### PR DESCRIPTION
1. Reference Materials are now detected by lower and uppercase first letter T. Note - this is still a hard-coded parameter that will be addressed later.
2. An off-by-one bug was discovered running example file ILC-IV-9peak-bkg3.xml with NOSBM and SPOTAV choices at lines 487 and 493 of PrawnFileRunFractionParser.  This was a remnant of the conversion of the code from VBA to JAva and from a mix of 0- and 1-based indexing in the VBA code to all zero-based indexing in the Java.